### PR TITLE
FIX: AD-1530 - fixed Artem's notes

### DIFF
--- a/bladeui/css/blade.scss
+++ b/bladeui/css/blade.scss
@@ -17,3 +17,4 @@
 @import 'blade/referralsForm.scss';
 @import 'blade/loader.scss';
 @import 'blade/infiniteScrollLoader.scss';
+@import 'blade/referralCode.scss';

--- a/bladeui/css/blade/referralCode.scss
+++ b/bladeui/css/blade/referralCode.scss
@@ -1,0 +1,12 @@
+.insert-referral-code-view {
+  form {
+    flex-grow: 1;
+    display: flex;
+    .form-group {
+      align-self: center;
+      .input-field {
+        padding: 14px;
+      }
+    }
+  }
+}

--- a/bladeui/css/blade/refferalsList.scss
+++ b/bladeui/css/blade/refferalsList.scss
@@ -14,6 +14,7 @@
     .referrals-list-content {
       overflow-x: hidden;
       .referrals-list-row {
+        position: relative;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -26,11 +27,15 @@
           font-size: 12px;
           color: #EEEEEE;
           &.email {
+            position: relative;
             width: 87px;
             overflow-x: hidden;
             text-overflow: ellipsis;
             text-align: left;
             white-space: nowrap;
+            &:hover + .info-tooltip {
+              display: block;
+            }
           }
 
           &.date {
@@ -40,6 +45,23 @@
 
           &.unit {
             text-transform: uppercase;
+          }
+        }
+
+        .info-tooltip {
+          display: none;
+          box-sizing: border-box;
+          height: 16px;
+          align-self: center;
+          position: absolute;
+          top: 100%;
+          left: 35px;
+          padding: 0px 3px;
+          color: #000;
+          width: auto;
+          background-color: #eee;
+          &::after {
+            left: 0;
           }
         }
 

--- a/bladeui/js/html/referralCode.js
+++ b/bladeui/js/html/referralCode.js
@@ -4,7 +4,7 @@ const header = require("./common/header");
 const input = require("./common/input");
 
 const html = `
-<div class="create-password-view flex-column">
+<div class="insert-referral-code-view flex-column">
   ${header("Insert a referral code")}
   <form>
     ${input({

--- a/bladeui/js/html/referralsMenuView.js
+++ b/bladeui/js/html/referralsMenuView.js
@@ -5,7 +5,7 @@ const menuList = require("./common/menuList");
 const statsRepresentation = require("./common/statsRepresentation");
 const referralsList = require("./common/referralsList");
 // eslint-disable-next-line max-len
-const TOOLTIP_TEXT = "Get rewarded for referrals! Earn 5 ADB for every invited friend that joins blade.";
+const TOOLTIP_TEXT = "Get rewarded for referrals!<br>Earn 5 ADB for every invited friend that joins blade.";
 
 const html = `
 ${menuList("referrals")}

--- a/bladeui/js/pages/referrals.js
+++ b/bladeui/js/pages/referrals.js
@@ -147,7 +147,7 @@ class Referrals extends BaseClass
           "<i class=\"icon-user-unfollow red\"></i>";
       }
       const date = formatDate(info[i].created_at);
-      newRow.innerHTML = `${userStatus}<p class="email">${info[i].email}</p><p class="date">${date}</p><p class="quantity">${rewardInfo}</p><p class="unit">ADB</p>`;
+      newRow.innerHTML = `${userStatus}<p class="email">${info[i].email}</p><p class="info-tooltip">${info[i].email}</p><p class="date">${date}</p><p class="quantity">${rewardInfo}</p><p class="unit">ADB</p>`;
       virtualRowContainer.appendChild(newRow);
     }
     this.hideLoader();

--- a/bladeui/skin/blade.css
+++ b/bladeui/skin/blade.css
@@ -788,6 +788,7 @@ button {
     .referrals-list-container .referrals-list .referrals-list-content {
       overflow-x: hidden; }
       .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row {
+        position: relative;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -800,16 +801,33 @@ button {
           font-size: 12px;
           color: #EEEEEE; }
           .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row p.email {
+            position: relative;
             width: 87px;
             overflow-x: hidden;
             text-overflow: ellipsis;
             text-align: left;
             white-space: nowrap; }
+            .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row p.email:hover + .info-tooltip {
+              display: block; }
           .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row p.date {
             width: 52px;
             text-align: right; }
           .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row p.unit {
             text-transform: uppercase; }
+        .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row .info-tooltip {
+          display: none;
+          box-sizing: border-box;
+          height: 16px;
+          align-self: center;
+          position: absolute;
+          top: 100%;
+          left: 35px;
+          padding: 0px 3px;
+          color: #000;
+          width: auto;
+          background-color: #eee; }
+          .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row .info-tooltip::after {
+            left: 0; }
         .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row i {
           font-size: 20px; }
         .referrals-list-container .referrals-list .referrals-list-content .referrals-list-row .red {
@@ -914,6 +932,9 @@ button {
     transform: translateY(-50%);
     cursor: pointer; }
 
+.referrals-view .form-group:first-of-type {
+  margin-bottom: 47px; }
+
 .referrals-view .form-group .input-field {
   font-size: 12px;
   color: #4A4A4A; }
@@ -990,3 +1011,11 @@ button {
     box-shadow: -15px 10px 0 rgba(217, 217, 217, 0), 0 10px rgba(217, 217, 217, 0), 15px 10px #d9d9d9; }
   100% {
     box-shadow: -15px 10px 0 rgba(217, 217, 217, 0), 0 10px rgba(217, 217, 217, 0), 15px 10px rgba(217, 217, 217, 0); } }
+
+.insert-referral-code-view form {
+  flex-grow: 1;
+  display: flex; }
+  .insert-referral-code-view form .form-group {
+    align-self: center; }
+    .insert-referral-code-view form .form-group .input-field {
+      padding: 14px; }


### PR DESCRIPTION
- email hover shows whole email
- referral code input reduce unnecessary space on the right
- separate the tool-tip's text of the Referrals info button to two paragraphs
- default message for referral invitation letter
- The Skip button after invalid ref-code submitting leads to the next set-up step